### PR TITLE
Text based fields shouldn't be nullable

### DIFF
--- a/django_facebook/models.py
+++ b/django_facebook/models.py
@@ -10,17 +10,17 @@ class FacebookProfileModel(models.Model):
     NOTE: If you don't use this this abstract class, make sure you copy/paste
     the fields in.
     '''
-    about_me = models.TextField(blank=True, null=True)
-    facebook_id = models.BigIntegerField(blank=True, null=True, unique=True)
-    access_token = models.TextField(blank=True, null=True, help_text='Facebook token for offline access')
-    facebook_name = models.CharField(max_length=255, blank=True, null=True)
-    facebook_profile_url = models.TextField(blank=True, null=True)
-    website_url = models.TextField(blank=True, null=True)
-    blog_url = models.TextField(blank=True, null=True)
+    about_me = models.TextField(blank=True)
+    facebook_id = models.BigIntegerField(blank=True, unique=True, null=True)
+    access_token = models.TextField(blank=True, help_text='Facebook token for offline access')
+    facebook_name = models.CharField(max_length=255, blank=True)
+    facebook_profile_url = models.TextField(blank=True)
+    website_url = models.TextField(blank=True)
+    blog_url = models.TextField(blank=True)
     image = models.ImageField(blank=True, null=True,
         upload_to='profile_images', max_length=255)
     date_of_birth = models.DateField(blank=True, null=True)
-    raw_data = models.TextField(blank=True, null=True)
+    raw_data = models.TextField(blank=True)
 
     def __unicode__(self):
         return self.user.__unicode__()


### PR DESCRIPTION
Hi there,

First of all, thanks for this excellent app. I'm currently using it for one of my projects. 

This patch removed "null=True" from text based fields in `FacebookProfileModel`. From django's docs:

Only use null=True for non-string fields such as integers, booleans and dates. All tests pass :)

Hope this helps!
Selwin
