### PR TITLE
Fixed catching HTTP error codes

### DIFF
--- a/open_facebook/api.py
+++ b/open_facebook/api.py
@@ -102,7 +102,7 @@ class FacebookConnection(object):
                                                 timeout=timeout)
                 except (urllib2.HTTPError,), e:
                     # catch the silly status code errors
-                    if 'HTTP Error' in unicode(e):
+                    if 'http error' in str(e).lower():
                         response_file = e
                     else:
                         raise


### PR DESCRIPTION
Discovered this while using the @facebook_required decorator. If user's token has expired then FacebookConnection didn't properly catch HTTP 400 sent back.
