### PR TITLE
Fix some minor bugs

### DIFF
--- a/django_facebook/decorators.py
+++ b/django_facebook/decorators.py
@@ -11,7 +11,8 @@ logger = logging.getLogger(__name__)
 
 
 def facebook_required(view_func=None, scope=fb_settings.FACEBOOK_DEFAULT_SCOPE,
-                      redirect_field_name=REDIRECT_FIELD_NAME, login_url=None, canvas=False):
+                      redirect_field_name=REDIRECT_FIELD_NAME,
+                      login_url=None, redirect_url=None, canvas=False):
     """
     Decorator which makes the view require the given Facebook perms,
     redirecting to the log-in page if necessary.
@@ -26,8 +27,10 @@ def facebook_required(view_func=None, scope=fb_settings.FACEBOOK_DEFAULT_SCOPE,
     def actual_decorator(view_func):
         @wraps(view_func, assigned=available_attrs(view_func))
         def _wrapped_view(request, *args, **kwargs):
-            oauth_url, redirect_uri = get_oauth_url(request, scope_list)
-            if test_permissions(request, scope_list, redirect_uri):
+            oauth_url, redirect_uri = get_oauth_url(request, scope_list,
+                    redirect_uri=redirect_url, canvas=canvas)
+            if test_permissions(request, scope_list, redirect_uri,
+                    canvas=canvas):
                 return view_func(request, *args, **kwargs)
             else:
                 logger.info('requesting access with redirect uri: %s',
@@ -44,7 +47,8 @@ def facebook_required(view_func=None, scope=fb_settings.FACEBOOK_DEFAULT_SCOPE,
 def facebook_required_lazy(view_func=None,
                            scope=fb_settings.FACEBOOK_DEFAULT_SCOPE,
                            redirect_field_name=REDIRECT_FIELD_NAME,
-                           login_url=None, extra_params=None, canvas=False):
+                           login_url=None, redirect_url=None,
+                           extra_params=None, canvas=False):
     """
     Decorator which makes the view require the given Facebook perms,
     redirecting to the log-in page if necessary.
@@ -59,7 +63,7 @@ def facebook_required_lazy(view_func=None,
         @wraps(view_func, assigned=available_attrs(view_func))
         def _wrapped_view(request, *args, **kwargs):
             oauth_url, redirect_uri = get_oauth_url(request, scope_list,
-                                                    extra_params=extra_params)
+                    redirect_uri=redirect_url, canvas=canvas)
             try:
                 # call get persistent graph and convert the
                 # token with correct redirect uri


### PR DESCRIPTION
- Fix endless redirects/broken url on permission request

I had some issues with the way django-facebook prevents "endless redirects". The oauth sometimes didn't like very much the fact that we had &attempt=1 in the url, so I skipped the "attempt" when in canvas mode.
- Fix problems with permissions revoke/expired session
  I had some nasty issues when I revoke my permissions the the app and then try to login while I still have the session cookie. Stale cache is no very nice...
