### PR TITLE
Fix UnicodeDecodeError error

### DIFF
--- a/django_facebook/connect.py
+++ b/django_facebook/connect.py
@@ -193,7 +193,7 @@ def _register_user(request, facebook, profile_callback=None,
         initial={'ip': request.META['REMOTE_ADDR']})
 
     if not form.is_valid():
-        error_message_format = u'Facebook data %s gave error %s'
+        error_message_format = 'Facebook data %s gave error %s'
         error_message = error_message_format % (facebook_data, form.errors)
         error = facebook_exceptions.IncompleteProfileError(error_message)
         error.form = form

--- a/django_facebook/views.py
+++ b/django_facebook/views.py
@@ -98,8 +98,8 @@ def connect(request):
                     logger.info('Django facebook performed action: %s', action)
                 except facebook_exceptions.IncompleteProfileError, e:
                     #show them a registration form to add additional data
-                    warning_format = u'Incomplete profile data encountered with error %s'
-                    warn_message = warning_format % e.message
+                    warn_message = 'Incomplete profile data encountered '\
+                        'with error %s' % e.message.decode('utf-8', 'replace')
                     send_warning(warn_message, e=e,
                                  facebook_data=facebook_data)
 

--- a/open_facebook/utils.py
+++ b/open_facebook/utils.py
@@ -79,7 +79,7 @@ def send_warning(message, request=None, e=None, **extra_data):
 
     error_message = None
     if e:
-        error_message = unicode(e)
+        error_message = e
 
     data = {
          'username': username,


### PR DESCRIPTION
If getting an IncompleteProfileError, the unicode stuff was giving error and the result was an exception that crashed the app.
