### PR TITLE
Adds a FACEBOOK_REGISTRATION_REDIRECT setting

### DIFF
--- a/django_facebook/models.py
+++ b/django_facebook/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.core.urlresolvers import reverse
 from django_facebook import model_managers
 from django.conf import settings
+import settings as django_facebook_settings
 import os
 
 
@@ -50,7 +51,10 @@ class FacebookProfileModel(models.Model):
         Behaviour after registering with facebook
         '''
         from django_facebook.utils import next_redirect
-        default_url = reverse('facebook_connect')
+        if django_facebook_settings.FACEBOOK_REGISTRATION_REDIRECT:
+            default_url = django_facebook_settings.FACEBOOK_REGISTRATION_REDIRECT
+        else:
+            default_url = reverse('facebook_connect')
         response = next_redirect(request, default=default_url,
                                  next_key='register_next')
         response.set_cookie('fresh_registration', self.user_id)

--- a/django_facebook/settings.py
+++ b/django_facebook/settings.py
@@ -51,3 +51,5 @@ FACEBOOK_REGISTRATION_BACKEND = getattr(settings, 'FACEBOOK_REGISTRATION_BACKEND
 
 #Fall back redirect location when no other location was found
 FACEBOOK_LOGIN_DEFAULT_REDIRECT = getattr(settings, 'FACEBOOK_LOGIN_DEFAULT_REDIRECT', '/') 
+
+FACEBOOK_REGISTRATION_REDIRECT = getattr(settings, 'FACEBOOK_REGISTRATION_REDIRECT', None)


### PR DESCRIPTION
Adds a FACEBOOK_REGISTRATION_REDIRECT settings
Has models.FacebookProfileModel.post_facebook_registration set this as default_url if the settings exists.

---

IMO, this is a much more clear way to allow users to have a redirect upon registration than the next_key method. Furthermore, it allows you to no mess with forms.

I'm not sure exactly how it should be implemented. This is a starting point for discussion.

Let me know what you think, and if we move forward I'll include updates to docs and tests.

Cheers!
