### PR TITLE
User data and profile data updates

### DIFF
--- a/django_facebook/connect.py
+++ b/django_facebook/connect.py
@@ -276,16 +276,14 @@ def _update_user(user, facebook, overwrite=True):
     for f in facebook_fields:
         facebook_value = facebook_data.get(f, False)
         if facebook_value:
-            if (f in profile_field_names and hasattr(profile, f) and
-                not getattr(profile, f, False)):
+            if (f in profile_field_names and hasattr(profile, f)):
                 logger.debug('profile field %s changed from %s to %s', f,
-                             getattr(profile, f), facebook_value)
+                             getattr(profile, f, 'Empty'), facebook_value)
                 setattr(profile, f, facebook_value)
                 profile_dirty = True
-            elif (f in user_field_names and hasattr(user, f) and
-                  not getattr(user, f, False)):
+            elif (f in user_field_names and hasattr(user, f)):
                 logger.debug('user field %s changed from %s to %s', f,
-                             getattr(user, f), facebook_value)
+                             getattr(user, f, 'Empty'), facebook_value)
                 setattr(user, f, facebook_value)
                 user_dirty = True
 


### PR DESCRIPTION
The function _update_user just updated the user and profile data when the destination attributes were empty because "not gettattr(f, user, False)" was "True" only when user.f was empty (or not attribute at all but this never happens because there are a hasattr before)

I just remove the getattr because it's not needed, the attribute exists in the model because there is a proper hasattr (shortcut evaluation).

I also add a setting to control whether or not to force a profile/user data update on every login when using FacebookBackend as authentication backend (it includes fb_update_required in user object). This is useful when all the profile is facebook based, and you haven't any view to modify it.
