### PR TITLE
Fix Attribute Error on S3 in s3boto

### DIFF
--- a/django_facebook/connect.py
+++ b/django_facebook/connect.py
@@ -332,6 +332,7 @@ def _update_image(profile, image_url):
         file=image_temp, name=image_name, field_name='image', 
         content_type=content_type, size=image_size, charset=None
     )
+    image_file.seek(0)
     profile.image.save(image_name, image_file)
     image_temp.flush()
     profile_dirty = True


### PR DESCRIPTION
There is an incompatibility when s3boto is used to manage the media files, including avatars from facebook(via Django-facebook).

More about the issue:
- https://github.com/boto/boto/pull/643
- https://github.com/boto/boto/issues/883
