### PR TITLE
Fixes issue 215

### DIFF
--- a/django_facebook/models.py
+++ b/django_facebook/models.py
@@ -90,13 +90,12 @@ class BaseFacebookProfileModel(models.Model):
     def _extend_access_token(self, access_token):
         from open_facebook.api import FacebookAuthorization
         results = FacebookAuthorization.extend_access_token(access_token)
-        access_token, expires = results['access_token'], int(
-            results['expires'])
+        access_token = results['access_token']
         old_token = self.access_token
         token_changed = access_token != old_token
         message = 'a new' if token_changed else 'the same'
         log_format = 'Facebook provided %s token, which expires at %s'
-        expires_delta = datetime.timedelta(seconds=expires)
+        expires_delta = datetime.timedelta(days=60)
         logger.info(log_format, message, expires_delta)
         if token_changed:
             logger.info('Saving the new access token')


### PR DESCRIPTION
Fixes Exception when "Remove offline_access permission" is active. Facebook does not return expires therefore we should not check for it. All long lived access tokens last for 60 days so expires_delta is set to 60 days and the bug is fixed. 
