### PR TITLE
CSS tweak for benefit of django-pipeline.

### DIFF
--- a/django_facebook/static/css/facebook.css
+++ b/django_facebook/static/css/facebook.css
@@ -1,4 +1,3 @@
-
 #facebook_shade {
     position            : fixed;
     height              : 100%;
@@ -44,6 +43,6 @@
     top                 : 10px;
     width               : 16px;
     height              : 16px;
-    background          : url('../../static/images/facebook_close.png');
+    background          : url('../images/facebook_close.png');
     cursor              : pointer;
 }


### PR DESCRIPTION
Tweaking a CSS image URL which causes problems with django-pipeline.

There should be no side affects from this. I think the problem was
caused because the relative URL stepped outside the static root and 
then back in again.
