### PR TITLE
Test: Connect test fails as request.template is a list not an object

### DIFF
--- a/django_facebook/tests.py
+++ b/django_facebook/tests.py
@@ -122,7 +122,11 @@ class UserConnectViewTest(FacebookTest):
             self.assertEqual(wrapped_connect.call_count, 1)
             self.assertEqual(response.status_code, 200)
             self.assertTrue(response.context)
-            assert response.template.name in facebook_settings.FACEBOOK_REGISTRATION_TEMPLATE or response.template.name == facebook_settings.FACEBOOK_REGISTRATION_TEMPLATE
+            template_matched = False
+            for template in response.template:
+                if template.name in facebook_settings.FACEBOOK_REGISTRATION_TEMPLATE or template.name == facebook_settings.FACEBOOK_REGISTRATION_TEMPLATE:
+                    template_matched = True
+            self.assertTrue(template_matched)
 
     def test_slow_connect(self):
         '''


### PR DESCRIPTION
Hey,

This code seems to work for me, it has something to do with request.template being a list and not an object. It doesn't seem to be because of template inheritance although I thought it might be at first. This code should work in either case. Sorry about the mess of the last pull request. This one should be pep8 and actually work.

Cheers,

Chris
