### PR TITLE
Verifying that request.facebook is not None besides existing

### DIFF
--- a/django_facebook/api.py
+++ b/django_facebook/api.py
@@ -98,7 +98,7 @@ def get_facebook_graph(request=None, access_token=None, redirect_uri=None, raise
     from django.core.cache import cache
     parsed_data = None
     expires = None
-    if hasattr(request, 'facebook'):
+    if hasattr(request, 'facebook') and request.facebook:
         graph = request.facebook
         _add_current_user_id(graph, request.user)
         return graph


### PR DESCRIPTION
In get_facebook_graph function in the api.py file, you check if the request has a 'facebook'  attribute and if it has, it assumes this is the graph and stop processing. 

It happens that sometimes, this attribute exists, but it's None, not the actual graph, so we should also check if it's not None, besides its existence
