### PR TITLE
Add middleware for canvas apps:

### DIFF
--- a/django_facebook/canvas.py
+++ b/django_facebook/canvas.py
@@ -8,9 +8,10 @@ def generate_oauth_url(scope=facebook_settings.FACEBOOK_DEFAULT_SCOPE,
     canvas_page = (next if next is not None else
                    facebook_settings.FACEBOOK_CANVAS_PAGE)
     query_dict.update(dict(client_id=facebook_settings.FACEBOOK_APP_ID,
-                           redirect_uri=canvas_page, scope=scope))
+                           redirect_uri=canvas_page,
+                           scope=','.join(scope)))
     if extra_data:
         query_dict.update(extra_data)
-    auth_url = 'http://www.facebook.com/dialog/oauth?%s' % (
+    auth_url = 'https://www.facebook.com/dialog/oauth?%s' % (
         query_dict.urlencode(), )
     return auth_url

--- a/django_facebook/middlewares.py
+++ b/django_facebook/middlewares.py
@@ -1,0 +1,92 @@
+# -*- coding: UTF-8 -*-
+'''
+Created on Jan 9, 2013
+
+@author: dudu
+'''
+from urlparse import urlparse
+from open_facebook.api import FacebookAuthorization, OpenFacebook
+from django_facebook.canvas import generate_oauth_url
+from django_facebook.utils import CanvasRedirect
+from django_facebook.connect import connect_user
+from django.contrib.auth import logout
+from django_facebook import settings
+
+redirect_login_oauth = CanvasRedirect(redirect_to=generate_oauth_url(),
+                                      show_body=False)
+
+
+class FacebookCanvasMiddleWare(object):
+
+    def process_request(self, request):
+        """
+        check if referer is facebook. If yes, this is the canvas page:
+        if not return.
+        if yes:
+        1) look for error. if error=permission denied -> redirect to permission. if other error: check what it can be
+        2) get signed_request and parse it.
+        3) if user_id and access_token not it parsed data -> redirect to permission page
+        4) check permissions
+        5) user:
+        a) if user is authenticated: check if it's the same
+        b) user is not authenticated: connect
+        """
+        #check referer to see if this is the first access
+        #or it's part of navigation in app
+        #facebook always sends a POST reuqest
+        referer = request.META.get('HTTP_REFERER', None)
+        if referer:
+            urlparsed = urlparse(referer)
+            if not urlparsed.netloc.endswith('facebook.com'):
+                return
+            #when there is an error, we attempt to allow user to reauthenticate
+            if 'error' in request.GET:
+                return redirect_login_oauth
+        else:
+            return
+
+        #get signed_request
+        signed_request = request.POST.get('signed_request', None)
+        #not sure if this can happen, but better check anyway
+        if not signed_request:
+            return redirect_login_oauth
+
+        #get signed_request and redirect to authorization dialog if app not authorized by user
+        parsed_signed_request = FacebookAuthorization.parse_signed_data(signed_request)
+        if 'user_id' not in parsed_signed_request or 'oauth_token' not in parsed_signed_request:
+            return redirect_login_oauth
+
+        access_token = parsed_signed_request['oauth_token']
+        facebook_id = long(parsed_signed_request['user_id'])
+        #check for permissions
+        graph = OpenFacebook(access_token)
+        permissions = set(graph.permissions())
+        scope_list = set(settings.FACEBOOK_DEFAULT_SCOPE)
+        if scope_list - permissions:
+            return redirect_login_oauth
+        #check if user authenticated and if it's the same
+        if request.user.is_authenticated():
+            try:
+                current_user = request.user.get_profile()
+            except:
+                current_facebook_id = None
+            else:
+                current_facebook_id = current_user.facebook_id
+            if not current_facebook_id or current_facebook_id != facebook_id:
+                logout(request)
+                #clear possible caches
+                if hasattr(request, 'facebook'):
+                    del request.facebook
+                if request.session.get('graph', None):
+                    del request.session['graph']
+            else:
+                #save last access_token to make sure we always have the most recent one
+                current_user.access_token = access_token
+                current_user.save()
+        request.facebook = graph
+        if not request.user.is_authenticated():
+            _action, _user = connect_user(request, access_token, graph)
+        #override http method, since this actually is a GET
+        if request.method == 'POST':
+            request.method = 'GET'
+        return

--- a/django_facebook/templates/django_facebook/canvas_redirect.html
+++ b/django_facebook/templates/django_facebook/canvas_redirect.html
@@ -1,11 +1,13 @@
 <html>
     <head>
         <script>
-            var authUrl = '{{ location|safe }}';
-            top.location.href=authUrl;
+            var oauth_url = '{{ location|safe }}';
+            window.top.location = oauth_url;
         </script>
     </head>
     <body>
+    	{% if show_body %}
         Redirecting you to <a href="{{ location }}">{{ location }}</a>
+        {% endif %}
     </body>
 </html>

--- a/django_facebook/tests.py
+++ b/django_facebook/tests.py
@@ -1,7 +1,7 @@
 from __future__ import with_statement
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.urlresolvers import reverse
-from django.test.client import Client
+from django.test.client import Client, RequestFactory
 from django_facebook import exceptions as facebook_exceptions, \
     settings as facebook_settings, signals
 from django_facebook.api import get_facebook_graph, FacebookUserConverter, \
@@ -11,13 +11,17 @@ from django_facebook.connect import _register_user, connect_user, \
     CONNECT_ACTIONS
 from django_facebook.tests_utils.base import FacebookTest, LiveFacebookTest, \
     RequestMock
-from django_facebook.utils import cleanup_oauth_url, get_profile_class
+from django_facebook.utils import cleanup_oauth_url, get_profile_class,\
+    CanvasRedirect
 from functools import partial
 from mock import Mock, patch
-from open_facebook.api import FacebookConnection, FacebookAuthorization
+from open_facebook.api import FacebookConnection, FacebookAuthorization,\
+    OpenFacebook
 from open_facebook.exceptions import FacebookSSLError, FacebookURLError
 import logging
 import mock
+from django_facebook.middlewares import FacebookCanvasMiddleWare
+from django.contrib.sessions.middleware import SessionMiddleware
 
 
 logger = logging.getLogger(__name__)
@@ -432,3 +436,62 @@ class SignalTest(FacebookTest):
                                  'pre_update_signal'), True)
         self.assertEqual(hasattr(user.get_profile(),
                                  'post_update_signal'), True)
+
+
+def fake_connect(request, access_tokon, graph):
+    return ('action', 'user')
+
+
+class FacebookCanvasMiddlewareTest(FacebookTest):
+
+    def setUp(self):
+        super(FacebookCanvasMiddlewareTest, self).setUp()
+        self.factory = RequestFactory()
+        self.middleware = FacebookCanvasMiddleWare()
+        self.session_middleware = SessionMiddleware()
+
+    def get_canvas_url(self, data={}):
+        request = self.factory.post('/', data)
+        request.META['HTTP_REFERER'] = 'https://apps.facebook.com/canvas/'
+        self.session_middleware.process_request(request)
+        return request
+
+    def test_referer(self):
+        #test empty referer
+        request = self.factory.get('/')
+        self.assertIsNone(self.middleware.process_request(request))
+        #test referer not facebook
+        request = self.factory.get('/')
+        request.META['HTTP_REFERER'] = 'https://localhost:8000/'
+        self.assertIsNone(self.middleware.process_request(request))
+        request = self.get_canvas_url()
+        response = self.middleware.process_request(request)
+        self.assertIsInstance(response, CanvasRedirect)
+
+    def test_user_denied(self):
+        request = self.factory.get('/?error_reason=user_denied&error=access_denied&error_description=The+user+denied+your+request.')
+        request.META['HTTP_REFERER'] = 'https://apps.facebook.com/canvas/'
+        response = self.middleware.process_request(request)
+        self.assertIsInstance(response, CanvasRedirect)
+
+    @patch.object(FacebookAuthorization, 'parse_signed_data')
+    def test_non_auth_user(self, mocked_method=FacebookAuthorization.parse_signed_data):
+        mocked_method.return_value = {}
+        data = {'signed_request': 'dXairHLF8dfUKaL7ZFXaKmTsAglg0EkyHesTLnPcPAE.eyJhbGdvcml0aG0iOiJITUFDLVNIQTI1NiIsImlzc3VlZF9hdCI6MTM1ODA2MTU1MSwidXNlciI6eyJjb3VudHJ5IjoiYnIiLCJsb2NhbGUiOiJlbl9VUyIsImFnZSI6eyJtaW4iOjIxfX19'}
+        request = self.get_canvas_url(data=data)
+        response = self.middleware.process_request(request)
+        self.assertTrue(mocked_method.called)
+        self.assertIsInstance(response, CanvasRedirect)
+
+    @patch('django_facebook.middlewares.connect_user', fake_connect)
+    @patch.object(OpenFacebook, 'permissions')
+    @patch.object(FacebookAuthorization, 'parse_signed_data')
+    def test_auth_user(self, mocked_method_1=FacebookAuthorization.parse_signed_data,
+                       mocked_method_2=OpenFacebook.permissions):
+        data = {'signed_request': 'd7JQQIfxHgEzLIqJMeU9J5IlLg7shzPJ8DFRF55L52w.eyJhbGdvcml0aG0iOiJITUFDLVNIQTI1NiIsImV4cGlyZXMiOjEzNTgwNzQ4MDAsImlzc3VlZF9hdCI6MTM1ODA2ODU1MCwib2F1dGhfdG9rZW4iOiJBQUFGdk02MWpkT0FCQVBhWkNzR1pDM0dEVFZtdDJCWkFQVlpDc0F0aGNmdXBYUnhMN1cwUHBaQm53OEUwTzBBRVNYNjVaQ0JHdjZpOFRBWGhnMEpzbER5UmtmZUlnYnNHUmV2eHQxblFGZ0hNcFNpeTNWRTB3ZCIsInVzZXIiOnsiY291bnRyeSI6ImJyIiwibG9jYWxlIjoiZW5fVVMiLCJhZ2UiOnsibWluIjoyMX19LCJ1c2VyX2lkIjoiMTAwMDA1MDEyNDY2Nzg1In0'}
+        request = self.get_canvas_url(data=data)
+        request.user = AnonymousUser()
+        mocked_method_1.return_value = {'user_id': '123456', 'oauth_token': 'qwertyuiop'}
+        mocked_method_2.return_value = facebook_settings.FACEBOOK_DEFAULT_SCOPE
+        self.assertIsNone(self.middleware.process_request(request))
+        self.assertTrue(mocked_method_1.called)

--- a/django_facebook/utils.py
+++ b/django_facebook/utils.py
@@ -1,5 +1,5 @@
 try:
-    #using compatible_datetime instead of datetime only 
+    #using compatible_datetime instead of datetime only
     #not to override the original datetime package
     from django.utils import timezone as compatible_datetime
 except ImportError:
@@ -116,11 +116,12 @@ class CanvasRedirect(HttpResponse):
     '''
     Redirect for Facebook Canvas pages
     '''
-    def __init__(self, redirect_to):
+    def __init__(self, redirect_to, show_body=True):
         self.redirect_to = redirect_to
         self.location = iri_to_uri(redirect_to)
 
-        context = dict(location=self.location)
+        context = dict(location=self.location,
+                       show_body=show_body)
         js_redirect = render_to_string(
             'django_facebook/canvas_redirect.html', context)
 
@@ -454,6 +455,7 @@ def get_class_from_string(path, default='raise'):
         else:
             backend_class = default
     return backend_class
+
 
 def parse_like_datetime(dt):
     return datetime.strptime(dt, "%Y-%m-%dT%H:%M:%S+0000")

--- a/facebook_example/requirements/development.txt
+++ b/facebook_example/requirements/development.txt
@@ -3,3 +3,4 @@ django_facebook
 south
 PIL
 mock
+python-memcached


### PR DESCRIPTION
I created a middleware instead of a series of decorators for the canvas.

The reason for this is that the signed_request parameter is sent by facebook only when facebook sends the user to the app, not during navigation. 

This explains also in part the "Somehow facebook does give perms" error. In this case, what should be done is to redirect the user to login dialog and if the user has already authorized the app, it will send the signed_request parameter with the token to get the permissions.

I made a rebase, so we have only 1 commit.

add memcache to development requirements, otherwise tests fail with ImportError: No module named memcache
add middleware for canvas
if referer not facebook, we pass
add error denied detection
redirect user when app not authorized
connecting user when permissions are given
add verification for same user
checking for permisions
changed behavior for error in order to reauthenticate
made pep8 complaint
