### PR TITLE
Fixed South crashing while attempting to run migrations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,4 +148,5 @@ setup(
         'pytest-django',
     ],
     test_suite='runtests.runtests',
+    zip_safe=False,  # South can't run migrations on zipped eggs.
 )


### PR DESCRIPTION
South can't run migrations on zipped eggs.
