### PR TITLE
Remove check that was inadvertently added for testing.

### DIFF
--- a/django_facebook/urls.py
+++ b/django_facebook/urls.py
@@ -37,7 +37,7 @@ dev_patterns = patterns('django_facebook.example_views',
                         )
 
 # when developing enable the example views
-if settings.DEBUG or True:
+if settings.DEBUG:
     # only enable example views while developing
     urlpatterns += dev_patterns
 


### PR DESCRIPTION
Debug URLs get added during production. (I just now checked and it looks like your website has this issue too.)
