### PR TITLE
Add ability to set class mapping settings as strings

### DIFF
--- a/django_facebook/utils.py
+++ b/django_facebook/utils.py
@@ -638,6 +638,8 @@ def get_class_for(purpose):
     '''
     mapping = get_class_mapping()
     class_ = mapping[purpose]
+    if isinstance(class_, basestring):
+        class_ = get_class_from_string(class_)
     return class_
 
 


### PR DESCRIPTION
This is important so we can write our own user conversion class and avoid ImportError when trying to import our custom user conversion class on our project settings file:

Now both ways work:

``` python
from django_facebook.api import FacebookUserConverter

FACEBOOK_CLASS_MAPPING = {
    'user_conversion': FacebookUserConverter
}
```

or

``` python
FACEBOOK_CLASS_MAPPING = {
    'user_conversion': 'django_facebook.api.FacebookUserConverter'
}
```
