### PR TITLE
Ensure form is submitted via jquery trigger

### DIFF
--- a/django_facebook/connect.py
+++ b/django_facebook/connect.py
@@ -94,9 +94,6 @@ def connect_user(request, access_token=None, facebook_graph=None, connect_facebo
                     'parallel register encountered, slower thread is doing a login')
                 auth_user = authenticate(
                     facebook_id=facebook_data['id'], **kwargs)
-                if not auth_user:
-                    # We don't have a valid user so raise
-                    raise e
                 action = CONNECT_ACTIONS.LOGIN
                 user = _login_user(request, converter, auth_user, update=False)
 


### PR DESCRIPTION
I wanted the submission of the form to be handled using an ajax approach using jQuery. To do this I just needed to make a simple change so that the submission of the form is triggered using jQuery.

For anyone else that is trying to achieve the same result, the glue code that I used to tie this all together (which uses [ajaxForm](http://malsup.com/jquery/form/)) is as below:

``` javascript
var options = {
    success:  function(responseText, statusText, xhr, $form) {
        $('#facebook_container').remove();
        $('#fb-login-form').html(responseText);
    }
};
$('#fb-login-form').ajaxForm(options);
```

ps. Please ignore 2bb257b and the subsequent revert in 484ad0d - I decided to submit a separate pull request for that.
