### PR TITLE
Don't assume we have a valid auth_user

### DIFF
--- a/django_facebook/static/django_facebook/js/facebook.js
+++ b/django_facebook/static/django_facebook/js/facebook.js
@@ -68,7 +68,7 @@ facebookClass.prototype = {
                 //showloading
                 scope.connectLoading(gettext('Now loading your profile...'));
                 //submit the form
-                $(formElement).submit();
+                formElement.submit();
             } else {
                 var errorMessage = gettext('Sorry, we couldn\'t log you in. Please try again.');
                 scope.connectLoading(errorMessage, true, true);


### PR DESCRIPTION
I'm submitted this patch as I was having an IntegrityError which is caught and raised as AlreadyRegistered. 

However in this case, the issue was because my database schema was corrupted. I previously had a working version on migration 0008 then migrated to 0010 after which there was an issue with a foreign key relationship (or something to that matter).

Essentially this meant that `auth_user` was set to None and thus when _login_user is called it attempted to login the Anonymous user, which, of course, didn't work. I wasn't aware of the actual issue because I just received a message saying: `AnonymousUser has no attribute backend` (or something to that regard).

I thought about potentially looking at the IntegrityError and determining if the user already exists, however I thought this was a little clumsy. Another approach of course would be to do a lookup first however I thought the simplest approach would be to not assume we have an auth_user and raise the exception.

I note that the migrations have now been removed however I still think there is a valid case for the patch to exist - or something that would achieve the same result.

ps. Ignore 49e30f7 and the subsequent revert in 6c5e89e - I've submitted them in a separate pull request.
