### PR TITLE
get_persistent_graph session cache is never used.

### DIFF
--- a/django_facebook/api.py
+++ b/django_facebook/api.py
@@ -64,9 +64,9 @@ def get_persistent_graph(request, *args, **kwargs):
         # search for the graph in the session
         cached_graph_dict = request.session.get('graph_dict')
         if cached_graph_dict:
-            cached_graph = OpenFacebook()
-            cached_graph.__setstate__(cached_graph_dict)
-            cached_graph._me = None
+            graph = OpenFacebook()
+            graph.__setstate__(cached_graph_dict)
+            graph._me = None
 
     if not graph or require_refresh:
         # gets the new graph, note this might do token conversions (slow)


### PR DESCRIPTION
get_persistent_graph, method used by decorators stores the graph object in the session in order not to request access token every time.

But it does not use it.
