### PR TITLE
@facebook_required's get_redirect_uri() should return some variation on the /facebook/connect URI

### DIFF
--- a/django_facebook/decorators.py
+++ b/django_facebook/decorators.py
@@ -86,7 +86,7 @@ class FacebookRequired(object):
 
             # Otherwise check if this page is the connect page, if it is, use the default
             elif request.path == reverse('django_facebook.views.connect'):
-                next = urlencode({'next': settings.FACEBOOK_LOGIN_DEFAULT_REDIRECT})
+                next = urlencode({'next': fb_settings.FACEBOOK_LOGIN_DEFAULT_REDIRECT})
 
             # Finally assume we're on a regular site page and set next to request.path
             else:


### PR DESCRIPTION
@facebook_required's get_redirect_uri() should return some variation on 
the /facebook/connect URI

Previously: get_redirect_uri() always returned the current page's absolute URI,
which meant that if a non-logged-in user hit /settings, a view decorated with
@facebook_required, the redirect_uri that was sent to Facebook was the current
page's absolute URI (eg. http://www.foo.com/settings).

This incorrect URI meant that facebook would return the oauth session to
/settings?&code=AQCYz... etc. The 'settings' view does not know what to do
with the oauth data and everything falls apart quite dramatically.

This change makes get_redirect_uri always return the reversed URI for the
django_facebook.views.connect view.

In addition it now sets the next parameter based on some simple rules:
1. We should give preference to a param called 'next' in GET or POST.
2. If no 'next' exists in GET or POST but we are currently rendering the
   django_facebook.views.connect page, set 'next' to the default set by
   settings.FACEBOOK_LOGIN_DEFAULT_REDIRECT
3. Finally, if neither of the two previous conditionals were triggered, assume
   that we should set 'next' to the current path. (eg. /settings').

I could of course have this all very wrong and be doing something very stupid,
but this change was the only way I could use django_facebook and have a
non-logged in user hit a view that was decorated by @facebook_required.
Perhaps I am missing something very obvious?
