### PR TITLE
Add parameter "installed" to api/create_test_user

### DIFF
--- a/open_facebook/api.py
+++ b/open_facebook/api.py
@@ -509,7 +509,7 @@ class FacebookAuthorization(FacebookConnection):
         return app_access_token
 
     @classmethod
-    def create_test_user(cls, app_access_token, permissions=None, name=None):
+    def create_test_user(cls, app_access_token, permissions=None, name=None, installed=True):
         '''
         Creates a test user with the given permissions and name
 
@@ -521,6 +521,9 @@ class FacebookAuthorization(FacebookConnection):
 
         :param name:
             Optionally specify the name
+            
+        :param installed:
+            Optionally create the user without the app installed
         '''
         if not permissions:
             permissions = ['read_stream', 'publish_stream',
@@ -534,7 +537,7 @@ class FacebookAuthorization(FacebookConnection):
 
         kwargs = {
             'access_token': app_access_token,
-            'installed': True,
+            'installed': installed,
             'name': name,
             'method': 'post',
             'permissions': permissions,
@@ -548,7 +551,7 @@ class FacebookAuthorization(FacebookConnection):
         return test_user
 
     @classmethod
-    def get_or_create_test_user(cls, app_access_token, name=None, permissions=None, force_create=False):
+    def get_or_create_test_user(cls, app_access_token, name=None, permissions=None, force_create=False, installed=True):
         '''
         There is no supported way of get or creating a test user
         However
@@ -598,7 +601,7 @@ class FacebookAuthorization(FacebookConnection):
         else:
             # create the user
             test_user = cls.create_test_user(
-                app_access_token, permissions, name)
+                app_access_token, permissions, name, installed)
 
         return test_user
 


### PR DESCRIPTION
For testing purposes in our app we would appreciate the possibility to create test_users without the app already installed. We have added this functionality to the OpenFacebook/api.
