### PR TITLE
ensure username variable is not None before checking if profilephp in it

### DIFF
--- a/django_facebook/api.py
+++ b/django_facebook/api.py
@@ -466,7 +466,7 @@ class FacebookUserConverter(object):
         if link:
             username = link.split('/')[-1]
             username = cls._make_username(username)
-            if 'profilephp' in username:
+            if username and 'profilephp' in username:
                 username = None
 
         # try the email adress next


### PR DESCRIPTION
The current master version breaks on registration attempts because it tries to perform a check to see if profilephp is in username without ensuring username is not None.
