### PR TITLE
Ensure the user ID is correctly extracted from Facebook link

### DIFF
--- a/django_facebook/api.py
+++ b/django_facebook/api.py
@@ -464,7 +464,7 @@ class FacebookUserConverter(object):
         # start by checking the public profile link (your facebook username)
         link = facebook_data.get('link')
         if link:
-            username = link.split('/')[-1]
+            username = link.rstrip('/').split('/')[-1]
             username = cls._make_username(username)
             if username and 'profilephp' in username:
                 username = None


### PR DESCRIPTION
When the returned link has slash character(s) at the end, username will be extracted as blank. This fix strips all slash present at end of the URL before splitting.
