### PR TITLE
Rename depreacated @transaction.commit_on_success to @transaction.atomic

### DIFF
--- a/django_facebook/utils.py
+++ b/django_facebook/utils.py
@@ -313,7 +313,7 @@ def next_redirect(request, default='/', additional_params=None,
     return HttpResponseRedirect(redirect_url)
 
 
-@transaction.commit_on_success
+@transaction.atomic
 def mass_get_or_create(model_class, base_queryset, id_field, default_dict,
                        global_defaults):
     '''


### PR DESCRIPTION
Fixes these warnings:

```
home/user/.virtualenvs/proj/lib/python2.7/site-packages/django_facebook/utils.py:316: RemovedInDjango18Warning: commit_on_success is deprecated in favor of atomic.
```

The fix is a simple rename, no functionality should be affected:

> atomic allows us to create a block of code within which the atomicity on the database is guaranteed. If the block of code is successfully completed, the changes are committed to the database. If there is an exception, the changes are rolled back.

https://docs.djangoproject.com/en/dev/topics/db/transactions/#django.db.transaction.atomic
