### PR TITLE
add wheels support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [pytest]
-python_files=test*.py
-addopts=--tb=short -x
+    python_files=test*.py
+    addopts=--tb=short -x
+
+[bdist_wheel]
+    universal = 1


### PR DESCRIPTION
Python on Wheels

This adds wheels support for this package. When you release and upload to PyPI please do, 

`pip install wheel`
`python setup.py sdist bdist_wheel upload`

For details, http://wheel.readthedocs.org/ or http://pythonwheels.com
