### PR TITLE
Right argumetns to 'user_authenticate'

### DIFF
--- a/django_facebook/auth_backends.py
+++ b/django_facebook/auth_backends.py
@@ -35,7 +35,8 @@ class FacebookBackend(backends.ModelBackend):
         '''
         user_attribute = is_user_attribute('facebook_id')
         if user_attribute:
-            user = self.user_authenticate(*args, **kwargs)
+            kwargs1 = dict(filter(lambda(k,v): k in ['facebook_id', 'facebook_email'], kwargs.items()))
+            user = self.user_authenticate(*args, **kwargs1)
         else:
             user = self.profile_authenticate(*args, **kwargs)
         return user


### PR DESCRIPTION
When creating an account for the first time, the function 'user_authenticate' is called with the additional keyword arguments 'username' and 'password'. This results in an error (at least with Python 2.7.5). Not sure if this is the right fix, but the additional arguments have to be filtered out.
