### PR TITLE
add explicit kwargs to FacebookBackend.authenticate

### DIFF
--- a/django_facebook/auth_backends.py
+++ b/django_facebook/auth_backends.py
@@ -27,7 +27,7 @@ class FacebookBackend(backends.ModelBackend):
 
     '''
 
-    def authenticate(self, *args, **kwargs):
+    def authenticate(self, facebook_id=None, facebook_email=None):
         '''
         Route to either the user or profile table depending on which type of user
         customization we are using
@@ -35,9 +35,9 @@ class FacebookBackend(backends.ModelBackend):
         '''
         user_attribute = is_user_attribute('facebook_id')
         if user_attribute:
-            user = self.user_authenticate(*args, **kwargs)
+            user = self.user_authenticate(facebook_id, facebook_email)
         else:
-            user = self.profile_authenticate(*args, **kwargs)
+            user = self.profile_authenticate(facebook_id, facebook_email)
         return user
 
     def user_authenticate(self, facebook_id=None, facebook_email=None):


### PR DESCRIPTION
Added explicit kwargs to `FacebookBackend.authenticate` so that if e.g. `username` and `password` are passed to `django.contrib.auth.authenticate`, Django detects that they will not work for this backend and skips it.
