### PR TITLE
add kwargs to user_authenticate, fix for multiple auth backends

### DIFF
--- a/django_facebook/auth_backends.py
+++ b/django_facebook/auth_backends.py
@@ -40,7 +40,7 @@ class FacebookBackend(backends.ModelBackend):
             user = self.profile_authenticate(facebook_id, facebook_email)
         return user
 
-    def user_authenticate(self, facebook_id=None, facebook_email=None):
+    def user_authenticate(self, facebook_id=None, facebook_email=None, **kwargs):
         '''
         Authenticate the facebook user by id OR facebook_email
         We filter using an OR to allow existing members to connect with


### PR DESCRIPTION
There's a bug when use FacebookBackend and ModelBackend together.
Adding kwargs to user_authenticate to fix it.
