### PR TITLE
added FACEBOOK_APP_ID and FACEBOOK_APP_SECRET as kwargs

### DIFF
--- a/django_facebook/admin.py
+++ b/django_facebook/admin.py
@@ -64,10 +64,11 @@ class OpenGraphShareAdmin(admin.ModelAdmin):
     actions = [admin_actions.retry_open_graph_share,
                admin_actions.retry_open_graph_share_for_user]
 
-    def view_share(self, instance):
+    def view_share(self, instance, *args, **kwargs):
         share_id = instance.share_id
         url_format = 'https://developers.facebook.com/tools/explorer/%s/?method=GET&path=%s%%2F'
-        url = url_format % (facebook_settings.FACEBOOK_APP_ID, share_id)
+        facebook_app_id = kwargs.get(facebook_settings.FACEBOOK_APP_ID_KWARGS, facebook_settings.FACEBOOK_APP_ID)
+        url = url_format % (facebook_app_id, share_id)
         template = '<a href="%s">%s</a>' % (url, share_id)
         return template
     view_share.allow_tags = True

--- a/django_facebook/api.py
+++ b/django_facebook/api.py
@@ -92,7 +92,7 @@ def get_persistent_graph(request, *args, **kwargs):
     return graph
 
 
-def get_facebook_graph(request=None, access_token=None, redirect_uri=None, raise_=False):
+def get_facebook_graph(request=None, access_token=None, redirect_uri=None, raise_=False, *args, **kwargs):
     '''
     given a request from one of these
     - js authentication flow (signed cookie)
@@ -137,6 +137,7 @@ def get_facebook_graph(request=None, access_token=None, redirect_uri=None, raise
     if signed_data and 'oauth_token' in signed_data:
         access_token = signed_data['oauth_token']
 
+    facebook_app_id = kwargs.get(facebook_settings.FACEBOOK_APP_ID_KWARGS, facebook_settings.FACEBOOK_APP_ID)
     if not access_token:
         # easy case, code is in the get
         code = request.REQUEST.get('code')
@@ -145,7 +146,7 @@ def get_facebook_graph(request=None, access_token=None, redirect_uri=None, raise
 
         if not code:
             # signed request or cookie leading, base 64 decoding needed
-            cookie_name = 'fbsr_%s' % facebook_settings.FACEBOOK_APP_ID
+            cookie_name = 'fbsr_%s' % facebook_app_id
             cookie_data = request.COOKIES.get(cookie_name)
 
             if cookie_data:

--- a/django_facebook/canvas.py
+++ b/django_facebook/canvas.py
@@ -3,11 +3,14 @@ from django_facebook import settings as facebook_settings
 
 
 def generate_oauth_url(scope=facebook_settings.FACEBOOK_DEFAULT_SCOPE,
-                       next=None, extra_data=None):
+                       next=None, extra_data=None, *args, **kwargs):
     query_dict = QueryDict('', True)
-    canvas_page = (next if next is not None else
-                   facebook_settings.FACEBOOK_CANVAS_PAGE)
-    query_dict.update(dict(client_id=facebook_settings.FACEBOOK_APP_ID,
+    facebook_app_id = kwargs.get(facebook_settings.FACEBOOK_APP_ID_KWARGS,
+                                facebook_settings.FACEBOOK_APP_ID)
+    facebook_canvas_page = kwargs.get(facebook_settings.FACEBOOK_CANVAS_PAGE_KWARGS,
+                                    facebook_settings.FACEBOOK_CANVAS_PAGE)
+    canvas_page = (next if next is not None else facebook_canvas_page)
+    query_dict.update(dict(client_id=facebook_app_id,
                            redirect_uri=canvas_page,
                            scope=','.join(scope)))
     if extra_data:

--- a/django_facebook/settings.py
+++ b/django_facebook/settings.py
@@ -5,11 +5,22 @@ logger = logging.getLogger(__name__)
 
 # : Your facebook app id
 FACEBOOK_APP_ID = getattr(settings, 'FACEBOOK_APP_ID', None)
+
+# : Keyword argument name for facebook app id
+FACEBOOK_APP_ID_KWARGS = getattr(settings, 'FACEBOOK_APP_ID_KWARGS', 'facebook_app_id')
+
 # : Your facebook app secret
 FACEBOOK_APP_SECRET = getattr(settings, 'FACEBOOK_APP_SECRET', None)
+
+# : Keyword argument name for facebook app secret
+FACEBOOK_APP_SECRET_KWARGS = getattr(settings, 'FACEBOOK_APP_SECRET_KWARGS', 'facebook_app_secret')
+
 # : The default scope we should use, note that registration will break without email
 FACEBOOK_DEFAULT_SCOPE = getattr(settings, 'FACEBOOK_DEFAULT_SCOPE', [
     'email', 'user_about_me', 'user_birthday', 'user_website'])
+
+# : Keyword argument name for facebook app default scope
+FACEBOOK_DEFAULT_SCOPE_KWARGS = getattr(settings, 'FACEBOOK_DEFAULT_SCOPE_KWARGS', 'facebook_default_scope')
 
 # : If we should store likes
 FACEBOOK_STORE_LIKES = getattr(settings, 'FACEBOOK_STORE_LIKES', False)
@@ -28,9 +39,12 @@ default_registration_backend = 'django_facebook.registration_backends.FacebookRe
 FACEBOOK_REGISTRATION_BACKEND = getattr(
     settings, 'FACEBOOK_REGISTRATION_BACKEND', default_registration_backend)
 
-# Absolute canvas page url as per facebook standard
+# : Absolute canvas page url as per facebook standard
 FACEBOOK_CANVAS_PAGE = getattr(settings, 'FACEBOOK_CANVAS_PAGE',
                                'http://apps.facebook.com/django_facebook_test/')
+
+# Keyword argument name for facebook app canvas page
+FACEBOOK_CANVAS_PAGE_KWARGS = getattr(settings, 'FACEBOOK_CANVAS_PAGE_KWARGS', 'facebook_canvas_page')
 
 # Disable this setting if you don't want to store a local image
 FACEBOOK_STORE_LOCAL_IMAGE = getattr(

--- a/django_facebook/utils.py
+++ b/django_facebook/utils.py
@@ -228,14 +228,15 @@ def queryset_iterator(queryset, chunksize=1000, getfunc=getattr):
         gc.collect()
 
 
-def get_oauth_url(scope, redirect_uri, extra_params=None):
+def get_oauth_url(scope, redirect_uri, extra_params=None, *args, **kwargs):
     '''
     Returns the oAuth URL for the given scope and redirect_uri
     '''
     scope = parse_scope(scope)
+    facebook_app_id = kwargs.get(facebook_settings.FACEBOOK_APP_ID_KWARGS, facebook_settings.FACEBOOK_APP_ID)
     query_dict = QueryDict('', True)
     query_dict['scope'] = ','.join(scope)
-    query_dict['client_id'] = facebook_settings.FACEBOOK_APP_ID
+    query_dict['client_id'] = facebook_app_id
 
     query_dict['redirect_uri'] = redirect_uri
     oauth_url = 'https://www.facebook.com/dialog/oauth?'

--- a/django_facebook/views.py
+++ b/django_facebook/views.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 @csrf_exempt
 @facebook_required_lazy
-def connect(request, graph):
+def connect(request, graph, *args, **kwargs):
     '''
     Exception and validation functionality around the _connect view
     Separated this out from _connect to preserve readability
@@ -34,9 +34,10 @@ def connect(request, graph):
     '''
     backend = get_registration_backend()
     context = RequestContext(request)
+    facebook_app_id = kwargs.get(facebook_settings.FACEBOOK_APP_ID_KWARGS, facebook_settings.FACEBOOK_APP_ID)
 
     # validation to ensure the context processor is enabled
-    if not context.get('FACEBOOK_APP_ID'):
+    if not context.get('FACEBOOK_APP_ID') and not facebook_app_id:
         message = 'Please specify a Facebook app id and ensure the context processor is enabled'
         raise ValueError(message)
 


### PR DESCRIPTION
Changelog:
- added `FACEBOOK_APP_ID_KWARGS`, `FACEBOOK_APP_SECRET_KWARGS` and `FACEBOOK_DEFAULT_KWARGS` in `django_facebook/settings.py`
- modified functions where `FACEBOOK_APP_ID`, `FACEBOOK_APP_SECRET` and `FACEBOOK_DEFAULT` are used to accept `*args` and `**kwargs` and assign the appropriate value from `kwargs` or `facebook_settings`
- modified `FacebookAuthorization._client_info` to accept `client_id` and `client_secret`. These values are passed from calling functions.
