### PR TITLE
Fix: Unicode-objects must be encoded before hashing

### DIFF
--- a/django_facebook/utils.py
+++ b/django_facebook/utils.py
@@ -150,8 +150,8 @@ def try_get_profile(user):
 
 def hash_key(key):
     import hashlib
-    hashed = hashlib.md5(key).hexdigest()
-    return hashed
+    key = key.encode('utf-8')
+    return hashlib.md5(key).hexdigest()
 
 
 def parse_signed_request(signed_request_string):


### PR DESCRIPTION
This fix is for Python 3