### PR TITLE
Issues with Graph API consistency across older and newer instances of Facebook apps

### DIFF
--- a/open_facebook/api.py
+++ b/open_facebook/api.py
@@ -859,16 +859,30 @@ class OpenFacebook(FacebookConnection):
 
         :returns: dict
         '''
+        permissions_dict = {}
         try:
             permissions = {}
             permissions_response = self.get('me/permissions')
-            if permissions_response.get('data'):
-                permissions = permissions_response['data'][0]
-        except facebook_exceptions.OAuthException:
-            permissions = {}
-        permissions_dict = dict([(k, bool(int(v)))
+
+            # determine whether we're dealing with 1.0 or 2.0+
+            for permission in permissions_response.get('data', []):
+                # graph api 2.0+, returns multiple dicts with keys 'status' and 'permission'
+                if any(value in ['granted', 'declined'] for value in permission.values()):  
+                    for perm in permissions_response['data']:
+                        grant = perm.get('status') == 'granted'
+                        name = perm.get('permission')
+                        if grant and name:  # just in case something goes sideways
+                            permissions_dict[name] = grant
+                # graph api 1.0, returns single dict as {permission: intval}
+                elif any(value in [0, 1, '0', '1'] for value in permission.values()):  
+                    permissions = permissions_response['data'][0]
+                    permissions_dict = dict([(k, bool(int(v)))
                                  for k, v in permissions.items()
                                  if v == '1' or v == 1])
+                break
+        except facebook_exceptions.OAuthException:
+            pass
+
         return permissions_dict
 
     def has_permissions(self, required_permissions):


### PR DESCRIPTION
Due to the fact that Facebook is moving towards using at least Graph API 2.0, they started forcing newer application instances to use v2.0, even if you explicitly ask for v1.0. Since we can't rely on the API to return values approriate to the requested version at this point, I've written permission pulling so it _should_ accomodate both.
