### PR TITLE
Replace unicode with str to make it work on py3

### DIFF
--- a/open_facebook/api.py
+++ b/open_facebook/api.py
@@ -206,7 +206,7 @@ class FacebookConnection(object):
                 # These are often temporary errors, so we will retry before
                 # failing
                 error_format = 'Facebook encountered a timeout (%ss) or error %s'
-                logger.warn(error_format, extended_timeout, unicode(e))
+                logger.warn(error_format, extended_timeout, str(e))
                 attempts -= 1
                 if not attempts:
                     # if we have no more attempts actually raise the error


### PR DESCRIPTION
Seeing this in a project with python3 and DRF:

```
  File "users/serializers.py", line 69, in validate_facebook_token
    result = open_facebook.get('me')
  File "open_facebook/api.py", line 727, in get
    response = self.request(path, **kwargs)
  File "open_facebook/api.py", line 921, in request
    response = self._request(url, post_data)
  File "open_facebook/api.py", line 209, in _request
    logger.warn(error_format, extended_timeout, unicode(e))
```