### PR TITLE
One extra line keeps 1.6 support

### DIFF
--- a/django_facebook/models.py
+++ b/django_facebook/models.py
@@ -1,7 +1,10 @@
 from __future__ import unicode_literals
 from django.utils.encoding import python_2_unicode_compatible
 from django.conf import settings
-from django.contrib.contenttypes.fields import GenericForeignKey
+try:
+    from django.contrib.contenttypes.fields import GenericForeignKey
+except ImportError:
+    from django.contrib.contenttypes.generic import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models.base import ModelBase


### PR DESCRIPTION
This PR https://github.com/tschellenbach/Django-facebook/pull/516 breaks 1.6 compatibility.

I could not find Django version support policy, so I am sending this PR.

Thanks,