### PR TITLE
Add examples for  FACEBOOK_APP_ID and FACEBOOK_APP_SECRET to install…

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -27,8 +27,8 @@ Define the following settings in your settings.py file:
 
 ::
 
-    FACEBOOK_APP_ID
-    FACEBOOK_APP_SECRET
+    FACEBOOK_APP_ID = 12345...
+    FACEBOOK_APP_SECRET = str('12345...') [in Python 2.x]
 
 **Context processor**
 


### PR DESCRIPTION
…ation docs

Makes clear that FACEBOOK_APP_SECRET is a string [in Python 2.x].
[I did not check whether another installed app converted my '12345...' string to unicode, u'12345...' .]
In addition, in Python 3.x maybe we need bytes??

Examples help to avoid confusion whether FACEBOOK_APP_ID needs to be a (long?) integer or string.