### PR TITLE
Add get to parsed_response to type field

### DIFF
--- a/open_facebook/api.py
+++ b/open_facebook/api.py
@@ -236,7 +236,7 @@ class FacebookConnection(object):
         if parsed_response and isinstance(parsed_response, dict):
             # of course we have two different syntaxes
             if parsed_response.get('error'):
-                cls.raise_error(parsed_response['error']['type'],
+                cls.raise_error(parsed_response['error'].get('type'),
                                 parsed_response['error']['message'],
                                 parsed_response['error'].get('code'))
             elif parsed_response.get('error_code'):


### PR DESCRIPTION
I'm getting a facebook error without type key on parsed_respose['error'], so adding get instead of directly asking to key.