### PR TITLE
Django 19 updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 matrix:
   exclude:
     - python: 3.5
-      env: DJANGO_VERSION=">=1.8,<1.9"
+      env: DJANGO=">=1.8,<1.9"
 postgres:
   adapter: sqlite3
   database: django_fb_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,20 @@ language: python
 python:
   - 2.7
   - 3.4
+  - 3.5
 notifications:
   email:
     - thierryschellenbach@gmail.com
 env:
   # test the standalone functionality
-  - DJANGO=1.6.11 CUSTOM_USER_MODEL=0 MODE=standalone REQUIREMENTS=development6 SETTINGS=facebook_example.settings TESTS=django_facebook open_facebook
-  - DJANGO=1.6.11 CUSTOM_USER_MODEL=1 MODE=standalone REQUIREMENTS=development6 SETTINGS=facebook_example.settings TESTS=django_facebook open_facebook
-  - DJANGO=1.7.8 CUSTOM_USER_MODEL=0 MODE=standalone REQUIREMENTS=development7 SETTINGS=facebook_example.settings TESTS=django_facebook open_facebook
-  - DJANGO=1.7.8 CUSTOM_USER_MODEL=1 MODE=standalone REQUIREMENTS=development7 SETTINGS=facebook_example.settings TESTS=django_facebook open_facebook
-  - DJANGO=1.8.2 CUSTOM_USER_MODEL=0 MODE=standalone REQUIREMENTS=development7 SETTINGS=facebook_example.settings TESTS=django_facebook open_facebook
-  - DJANGO=1.8.2 CUSTOM_USER_MODEL=1 MODE=standalone REQUIREMENTS=development7 SETTINGS=facebook_example.settings TESTS=django_facebook open_facebook
+  - DJANGO=">=1.8,<1.9" CUSTOM_USER_MODEL=0 MODE=standalone REQUIREMENTS=development7 SETTINGS=facebook_example.settings TESTS=django_facebook open_facebook
+  - DJANGO=">=1.8,<1.9" CUSTOM_USER_MODEL=1 MODE=standalone REQUIREMENTS=development7 SETTINGS=facebook_example.settings TESTS=django_facebook open_facebook
+  - DJANGO=">=1.9,<1.10" CUSTOM_USER_MODEL=0 MODE=standalone REQUIREMENTS=development7 SETTINGS=facebook_example.settings TESTS=django_facebook open_facebook
+  - DJANGO=">=1.9,<1.10" CUSTOM_USER_MODEL=1 MODE=standalone REQUIREMENTS=development7 SETTINGS=facebook_example.settings TESTS=django_facebook open_facebook
+matrix:
+  exclude:
+    - python: 3.5
+      env: DJANGO_VERSION=">=1.8,<1.9"
 postgres:
   adapter: sqlite3
   database: django_fb_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ env:
 matrix:
   exclude:
     - python: 3.5
-      env: DJANGO=">=1.8,<1.9"
+      env: DJANGO=">=1.8,<1.9" CUSTOM_USER_MODEL=0 MODE=standalone REQUIREMENTS=development7 SETTINGS=facebook_example.settings TESTS=django_facebook open_facebook
+    - python: 3.5
+      env: DJANGO=">=1.8,<1.9" CUSTOM_USER_MODEL=1 MODE=standalone REQUIREMENTS=development7 SETTINGS=facebook_example.settings TESTS=django_facebook open_facebook
 postgres:
   adapter: sqlite3
   database: django_fb_test

--- a/README.rest
+++ b/README.rest
@@ -17,8 +17,8 @@ Contributions are strongly appreciated. Seriously, give github a try, fork and g
 
 News
 ----
-* django-facebook is now python 3 compatible!  With this change, django-facebook will be dropping support for django 1.4 and the mininum required django version will be 1.5.
-
+* django-facebook will be dropping support for django < 1.8 since `django only supports <https://www.djangoproject.com/download/#supported-versions>`_ versions 1.8 and above.
+  
 
 Demo & About
 ------------

--- a/django_facebook/api.py
+++ b/django_facebook/api.py
@@ -1,7 +1,4 @@
-try:
-    from django.forms.utils import ValidationError
-except ImportError:
-    from django.forms.util import ValidationError
+from django.core.exceptions import ValidationError
 
 from django_facebook import settings as facebook_settings, signals
 from django_facebook.exceptions import FacebookException
@@ -14,6 +11,7 @@ from open_facebook.utils import send_warning, validate_is_instance
 import datetime
 import json
 import logging
+
 try:
     from dateutil.parser import parse as parse_date
 except ImportError:

--- a/facebook_example/facebook_example/urls.py
+++ b/facebook_example/facebook_example/urls.py
@@ -1,38 +1,37 @@
 try:
     from django.conf.urls import include, patterns, url
 except ImportError:
-    from django.conf.urls.defaults import include, patterns, url
+    from django.conf.urls.defaults import include, url
 from django.conf import settings
 # Uncomment the next two lines to enable the admin:
 from django.contrib import admin
 admin.autodiscover()
 
-urlpatterns = patterns('',
-                       # facebook and registration urls
-                       (r'^facebook/', include('django_facebook.urls')),
-                       (r'^accounts/', include('django_facebook.auth_urls')),
+urlpatterns = [
+    # facebook and registration urls
+    url(r'^facebook/', include('django_facebook.urls')),
+    url(r'^accounts/', include('django_facebook.auth_urls')),
 
-                       # Uncomment the admin/doc line below to enable admin documentation:
-                       # (r'^admin/doc/', include('django.contrib.admindocs.urls')),
+    # Uncomment the admin/doc line below to enable admin documentation:
+    # (r'^admin/doc/', include('django.contrib.admindocs.urls')),
 
-                       # Uncomment the next line to enable the admin:
-                       (r'^admin/', include(admin.site.urls)),
-                       )
+    # Uncomment the next line to enable the admin:
+    url(r'^admin/', include(admin.site.urls)),
+]
 
 if settings.MODE == 'userena':
-    urlpatterns += patterns('',
-                            (r'^accounts/', include('userena.urls')),
-                            )
+    urlpatterns += [
+        url(r'^accounts/', include('userena.urls')),
+    ]
 elif settings.MODE == 'django_registration':
-    urlpatterns += patterns('',
-                            (r'^accounts/', include(
-                                'registration.backends.default.urls')),
-                            )
+    urlpatterns += [
+        url(r'^accounts/', include('registration.backends.default.urls')),
+    ]
 
 
 if settings.DEBUG:
-    urlpatterns += patterns('',
-                            url(r'^media/(?P<path>.*)$', 'django.views.static.serve', {
-                                'document_root': settings.MEDIA_ROOT,
-                                }),
-                            )
+    urlpatterns += [
+        url(r'^media/(?P<path>.*)$', 'django.views.static.serve', {
+            'document_root': settings.MEDIA_ROOT,
+            }),
+        ]

--- a/facebook_example/requirements/development6.txt
+++ b/facebook_example/requirements/development6.txt
@@ -1,2 +1,0 @@
--r development7.txt
-south==1.0.0


### PR DESCRIPTION
- Removed support for django < 1.8 since django no longer supports it.  
- Added python 3.5 to test against
- Fix import error for python 1.9.  

There's more to do with django 1.9, but this is a small start.

This fixes #559. I started diving into the test suite to get it running again and it was quite a handful to deal with.  That going to take a much bigger commitment. 
