### PR TITLE
Replace `request.REQUEST` with `POST` and `GET`

### DIFF
--- a/django_facebook/api.py
+++ b/django_facebook/api.py
@@ -113,7 +113,8 @@ def get_facebook_graph(request=None, access_token=None, redirect_uri=None, raise
     on the same page
     '''
     # this is not a production flow, but very handy for testing
-    query_access_token = request.POST.get('access_token', request.GET.get('access_token'))
+    query_access_token = request.POST.get('access_token',
+            request.GET.get('access_token'))
     if not access_token and query_access_token:
         access_token = query_access_token
     # should drop query params be included in the open facebook api,

--- a/django_facebook/api.py
+++ b/django_facebook/api.py
@@ -63,7 +63,7 @@ def get_persistent_graph(request, *args, **kwargs):
     # some situations like an expired access token require us to refresh our
     # graph
     require_refresh = False
-    code = request.REQUEST.get('code')
+    code = request.POST.get('code', request.GET.get('code'))
     if code:
         require_refresh = True
 
@@ -113,8 +113,9 @@ def get_facebook_graph(request=None, access_token=None, redirect_uri=None, raise
     on the same page
     '''
     # this is not a production flow, but very handy for testing
-    if not access_token and request.REQUEST.get('access_token'):
-        access_token = request.REQUEST['access_token']
+    query_access_token = request.POST.get('access_token', request.GET.get('access_token'))
+    if not access_token and query_access_token:
+        access_token = query_access_token
     # should drop query params be included in the open facebook api,
     # maybe, weird this...
     from open_facebook import OpenFacebook, FacebookAuthorization
@@ -128,7 +129,8 @@ def get_facebook_graph(request=None, access_token=None, redirect_uri=None, raise
     # parse the signed request if we have it
     signed_data = None
     if request:
-        signed_request_string = request.REQUEST.get('signed_data')
+        signed_request_string = request.POST.get('signed_data',
+            request.GET.get('signed_data'))
         if signed_request_string:
             logger.info('Got signed data from facebook')
             signed_data = parse_signed_request(signed_request_string)
@@ -141,7 +143,7 @@ def get_facebook_graph(request=None, access_token=None, redirect_uri=None, raise
 
     if not access_token:
         # easy case, code is in the get
-        code = request.REQUEST.get('code')
+        code = request.POST.get('code', request.GET.get('code'))
         if code:
             logger.info('Got code from the request data')
 

--- a/django_facebook/connect.py
+++ b/django_facebook/connect.py
@@ -52,8 +52,10 @@ def connect_user(request, access_token=None, facebook_graph=None, connect_facebo
 
     assert converter.is_authenticated()
     facebook_data = converter.facebook_profile_data()
-    force_registration = request.REQUEST.get('force_registration') or\
-        request.REQUEST.get('force_registration_hard')
+    force_registration = request.POST.get('force_registration') or \
+            request.GET.get('force_registration') or \
+            request.POST.get('force_registration_hard') or \
+            request.GET.get('force_registration_hard')
 
     logger.debug('force registration is set to %s', force_registration)
     if connect_facebook and request.user.is_authenticated() and not force_registration:
@@ -139,7 +141,8 @@ def _connect_user(request, facebook, overwrite=True):
 
     # see if we already have profiles connected to this Facebook account
     old_connections = _get_old_connections(facebook_id, request.user.id)[:20]
-    if old_connections and not request.REQUEST.get('confirm_connect'):
+    if old_connections and not (request.POST.get('confirm_connect') or \
+                                request.GET.get('confirm_connect')):
         raise facebook_exceptions.AlreadyConnectedError(list(old_connections))
     user = _update_user(request.user, facebook, overwrite=overwrite)
 
@@ -221,7 +224,8 @@ def _register_user(request, facebook, profile_callback=None,
     if remove_old_connections:
         _remove_old_connections(facebook_data['facebook_id'])
 
-    if request.REQUEST.get('force_registration_hard'):
+    if request.POST.get('force_registration_hard') or \
+           request.GET.get('force_registration_hard'):
         data['email'] = data['email'].replace(
             '@', '+test%s@' % randint(0, 1000000000))
 

--- a/django_facebook/decorators.py
+++ b/django_facebook/decorators.py
@@ -55,7 +55,7 @@ class FacebookRequired(object):
         if permissions_granted:
             response = self.execute_view(
                 fn, request, graph=graph, *args, **kwargs)
-        elif request.REQUEST.get('attempt') == '1':
+        elif request.POST.get('attempt', request.GET.get('attempt')) == '1':
             # Doing a redirect could end up causing infinite redirects
             # If Facebook is somehow not giving permissions
             # Time to show an error page
@@ -185,7 +185,7 @@ class FacebookRequiredLazy(FacebookRequired):
                 # shouldn't have been caught
                 # raise to prevent bugs with error mapping to cause issues
                 raise
-            elif request.REQUEST.get('attempt') == '1':
+            elif request.POST.get('attempt', request.GET.get('attempt')) == '1':
                 # Doing a redirect could end up causing infinite redirects
                 # If Facebook is somehow not giving permissions
                 # Time to show an error page

--- a/django_facebook/templates/django_facebook/example.html
+++ b/django_facebook/templates/django_facebook/example.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 
 <html><head>
     <title>Connect with Facebook</title>

--- a/django_facebook/test_utils/mocks.py
+++ b/django_facebook/test_utils/mocks.py
@@ -13,7 +13,8 @@ class RequestMock(RequestFactory):
 
     def request(self, **request):
         "Construct a generic request object."
-        request['REQUEST'] = dict()
+        request['POST'] = dict()
+        request['GET'] = dict()
         request = RequestFactory.request(self, **request)
         handler = BaseHandler()
         handler.load_middleware()

--- a/django_facebook/utils.py
+++ b/django_facebook/utils.py
@@ -298,7 +298,7 @@ def next_redirect(request, default='/', additional_params=None,
     # get the redirect url
     if not redirect_url:
         for key in next_key:
-            redirect_url = request.REQUEST.get(key)
+            redirect_url = request.POST.get(key, requrest.GET.get(key))
             if redirect_url:
                 break
         if not redirect_url:

--- a/django_facebook/views.py
+++ b/django_facebook/views.py
@@ -57,8 +57,10 @@ def _connect(request, graph):
     So we know we either have a graph and permissions, or the user denied
     the oAuth dialog
     '''
+
     backend = get_registration_backend()
-    connect_facebook = to_bool(request.REQUEST.get('connect_facebook'))
+    qdict = request.GET if request.method == 'GET' else request.POST
+    connect_facebook = to_bool(qdict.get('connect_facebook'))
 
     logger.info('trying to connect using Facebook')
     if graph:

--- a/django_facebook/views.py
+++ b/django_facebook/views.py
@@ -57,10 +57,11 @@ def _connect(request, graph):
     So we know we either have a graph and permissions, or the user denied
     the oAuth dialog
     '''
-
     backend = get_registration_backend()
-    qdict = request.GET if request.method == 'GET' else request.POST
-    connect_facebook = to_bool(qdict.get('connect_facebook'))
+    connect_facebook = to_bool(
+        request.POST.get('connect_facebook',
+             request.GET.get('connect_facebook'))
+    )
 
     logger.info('trying to connect using Facebook')
     if graph:


### PR DESCRIPTION
Addresses #558, but not in the most ideal way.

Django deprecated `request.REQUEST` in 1.7 and removed it in 1.8.  Developers are advised to ["Use the more explicit GET and POST instead."](https://docs.djangoproject.com/en/1.8/ref/request-response/#django.http.HttpRequest.REQUEST)

This PR does not choose which of POST or GET to use in each of the previous invocations of `request.REQUEST`, instead, it just repeats the old functionality of `request.REQUEST` (check `POST` first, then check `GET`).  It would be more ideal to go through and pick one of POST or GET depending on what the method expects, or if it really needs to use both, to keep logic such as this PR uses.

In short: this PR keeps the same prior functionality, but does not improve it in the manner Django maintainers intended by deprecating `request.REQUEST`.

Also: removes the `load url from future` from the example view. The future is now, and url can no longer be loaded from it. :)