### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rest
+++ b/README.rest
@@ -58,22 +58,22 @@ Documentation
 
 **Basics**
 
-* `Installation <http://django-facebook.readthedocs.org/en/latest/installation.html>`_
-* `Customizing <http://django-facebook.readthedocs.org/en/latest/customizing.html>`_
-* `Settings <http://django-facebook.readthedocs.org/en/latest/settings.html>`_
-* `Registration backends & Redirects <http://django-facebook.readthedocs.org/en/latest/registration_backend.html>`_
+* `Installation <https://django-facebook.readthedocs.io/en/latest/installation.html>`_
+* `Customizing <https://django-facebook.readthedocs.io/en/latest/customizing.html>`_
+* `Settings <https://django-facebook.readthedocs.io/en/latest/settings.html>`_
+* `Registration backends & Redirects <https://django-facebook.readthedocs.io/en/latest/registration_backend.html>`_
 
 **Open Facebook API**
 
-* `Getting an OpenFacebook object <http://django-facebook.readthedocs.org/en/latest/graph.html>`_
-* `Making calls <http://django-facebook.readthedocs.org/en/latest/open_facebook/api.html>`_
+* `Getting an OpenFacebook object <https://django-facebook.readthedocs.io/en/latest/graph.html>`_
+* `Making calls <https://django-facebook.readthedocs.io/en/latest/open_facebook/api.html>`_
 
 **Advanced**
 
-* `Mobile <http://django-facebook.readthedocs.org/en/latest/mobile.html>`_
-* `Celery <http://django-facebook.readthedocs.org/en/latest/celery.html>`_
-* `Signals <http://django-facebook.readthedocs.org/en/latest/signals.html>`_
-* `Canvas <http://django-facebook.readthedocs.org/en/latest/canvas.html>`_
+* `Mobile <https://django-facebook.readthedocs.io/en/latest/mobile.html>`_
+* `Celery <https://django-facebook.readthedocs.io/en/latest/celery.html>`_
+* `Signals <https://django-facebook.readthedocs.io/en/latest/signals.html>`_
+* `Canvas <https://django-facebook.readthedocs.io/en/latest/canvas.html>`_
 
 
 Contributing and Running tests

--- a/facebook_example/facebook_example/settings.py
+++ b/facebook_example/facebook_example/settings.py
@@ -169,7 +169,7 @@ INSTALLED_APPS = (
 if django_version < (1, 7, 0):
     # south isn't needed by django >= 1.7 since migrations were added.  See:
     # - https://docs.djangoproject.com/en/dev/topics/migrations/#libraries-third-party-apps
-    # - http://south.readthedocs.org/en/latest/releasenotes/1.0.html#library-migration-path
+    # - https://south.readthedocs.io/en/latest/releasenotes/1.0.html#library-migration-path
     INSTALLED_APPS += ('south',)
 
 # A sample logging configuration. The only tangible logging


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
