### PR TITLE
remove str to stop UnicodeEncodeError

### DIFF
--- a/django_facebook/api.py
+++ b/django_facebook/api.py
@@ -457,7 +457,7 @@ class FacebookUserConverter(object):
             get_user_model().objects.filter(
                 username__istartswith=base_username
             ).values_list('username', flat=True))
-        usernames_lower = [str(u).lower() for u in usernames]
+        usernames_lower = [u.lower() for u in usernames]
         username = str(base_username)
         i = 1
         while base_username.lower() in usernames_lower:


### PR DESCRIPTION
I was getting an error ''ascii' codec can't encode character u'\xe9' in position 4: ordinal not in range(128)' The database contains usernames such as 'ZoëM98468' and with the str in it errors here. I have tested without the str and this function no longer errors. 