### PR TITLE
Fix unit tests + add django 1 11 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
   - "pep8 --exclude=south_migrations --ignore=E501,E225,W293,E731 django_facebook open_facebook"
 #  - pyflakes -x W src
 script:
-  - pip uninstall django-facebook && pip install -e .
+  - pip uninstall -y django-facebook && pip install -e .
   - cd facebook_example
   - coverage run manage.py test $TESTS --settings=$SETTINGS -v2
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ postgres:
   database: django_fb_test
 install:
   # faster than installing PIL manually
-  - pip install pep8 --use-mirrors
-  - pip install coverage --use-mirrors
-  - pip install python-coveralls --use-mirrors
+  - pip install pep8
+  - pip install coverage
+  - pip install python-coveralls
   - pip install https://github.com/dcramer/pyflakes/tarball/master
   - python setup.py install
-  - pip install -r facebook_example/requirements/$REQUIREMENTS.txt --use-mirrors -I --allow-all-external
-  - pip install -q Django$DJANGO --use-mirrors -I
+  - pip install -r facebook_example/requirements/$REQUIREMENTS.txt -I --allow-all-external
+  - pip install -q Django$DJANGO -I
 before_script:
   - "pep8 --exclude=south_migrations --ignore=E501,E225,W293,E731 django_facebook open_facebook"
 #  - pyflakes -x W src

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
   - "pep8 --exclude=south_migrations --ignore=E501,E225,W293,E731 django_facebook open_facebook"
 #  - pyflakes -x W src
 script:
-  - pip install -e .
+  - pip uninstall django-facebook && pip install -e .
   - cd facebook_example
   - coverage run manage.py test $TESTS --settings=$SETTINGS -v2
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ notifications:
   email:
     - thierryschellenbach@gmail.com
 env:
-  # test the standalone functionality
+  # test the standalone functionality (skipping django 1.10 to minimize the number of machines used on Travis)
   - DJANGO=">=1.8,<1.9" CUSTOM_USER_MODEL=0 MODE=standalone REQUIREMENTS=development7 SETTINGS=facebook_example.settings TESTS=django_facebook open_facebook
   - DJANGO=">=1.8,<1.9" CUSTOM_USER_MODEL=1 MODE=standalone REQUIREMENTS=development7 SETTINGS=facebook_example.settings TESTS=django_facebook open_facebook
   - DJANGO=">=1.9,<1.10" CUSTOM_USER_MODEL=0 MODE=standalone REQUIREMENTS=development7 SETTINGS=facebook_example.settings TESTS=django_facebook open_facebook
   - DJANGO=">=1.9,<1.10" CUSTOM_USER_MODEL=1 MODE=standalone REQUIREMENTS=development7 SETTINGS=facebook_example.settings TESTS=django_facebook open_facebook
+  - DJANGO=">=1.11,<1.12" CUSTOM_USER_MODEL=0 MODE=standalone REQUIREMENTS=development7 SETTINGS=facebook_example.settings TESTS=django_facebook open_facebook
+  - DJANGO=">=1.11,<1.12" CUSTOM_USER_MODEL=1 MODE=standalone REQUIREMENTS=development7 SETTINGS=facebook_example.settings TESTS=django_facebook open_facebook
 matrix:
   exclude:
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - pip install https://github.com/dcramer/pyflakes/tarball/master
   - python setup.py install
   - pip install -r facebook_example/requirements/$REQUIREMENTS.txt -I --allow-all-external
-  - pip install Django$DJANGO -I
+  - pip install Django$DJANGO
 before_script:
   - "pep8 --exclude=south_migrations --ignore=E501,E225,W293,E731 django_facebook open_facebook"
 #  - pyflakes -x W src

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - pip install https://github.com/dcramer/pyflakes/tarball/master
   - python setup.py install
   - pip install -r facebook_example/requirements/$REQUIREMENTS.txt -I --allow-all-external
-  - pip install -q Django$DJANGO -I
+  - pip install Django$DJANGO -I
 before_script:
   - "pep8 --exclude=south_migrations --ignore=E501,E225,W293,E731 django_facebook open_facebook"
 #  - pyflakes -x W src

--- a/django_facebook/models.py
+++ b/django_facebook/models.py
@@ -19,6 +19,7 @@ from open_facebook.exceptions import OAuthException
 import logging
 import os
 
+
 def get_user_model_setting():
     from django.conf import settings
     default = 'auth.User'
@@ -591,7 +592,7 @@ class OpenGraphShare(BaseModel):
                     id=user_or_profile.id)
                 token_changed = graph.access_token != user_or_profile.access_token
                 logging.info('new token required is %s and token_changed is %s',
-                            new_token_required, token_changed)
+                             new_token_required, token_changed)
                 if new_token_required and not token_changed:
                     logging.info(
                         'a new token is required, setting the flag on the user or profile')

--- a/django_facebook/tests.py
+++ b/django_facebook/tests.py
@@ -98,11 +98,7 @@ class DecoratorTest(BaseDecoratorTest):
         We should redirect to Facebook oauth dialog
         '''
         response = self.client.get(self.url, follow=True)
-        if six.PY3:
-            self.assertEqual(response.redirect_chain[0][1], 302)
-        else:
-            self.assertRedirects(
-                response, self.target_url, target_status_code=404)
+        self.assertEqual(response.redirect_chain[0][1], 302)
 
     def test_decorator_authenticated(self):
         '''

--- a/django_facebook/tests.py
+++ b/django_facebook/tests.py
@@ -604,7 +604,6 @@ class UserConnectTest(FacebookTest):
         action, user = connect_user(self.request, facebook_graph=graph)
         self.assertEqual(action, CONNECT_ACTIONS.REGISTER)
 
-        self.request.user.is_authenticated = lambda: False
         with patch('django_facebook.connect.authenticate') as patched:
             return_sequence = [user, None]
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,35 +36,41 @@ add django facebook to your installed apps::
 
     'django_facebook',
 
-Add this line to your context processors (``TEMPLATE_CONTEXT_PROCESSORS`` setting)::
+Add this line to EACH of your templates' context processors (``TEMPLATES[*]['OPTIONS']['context_processors']`` setting)::
 
     'django_facebook.context_processors.facebook',
     # and add request if you didn't do so already
     'django.core.context_processors.request',
 
-The full setting on a new django 1.5 app looks like this
+The full setting on a new django 1.11 app looks like this
 
 .. code-block:: python
 
-  TEMPLATE_CONTEXT_PROCESSORS = (
-      'django.contrib.auth.context_processors.auth',
-      'django.core.context_processors.debug',
-      'django.core.context_processors.i18n',
-      'django.core.context_processors.media',
-      'django.core.context_processors.static',
-      'django.core.context_processors.tz',
-      'django.core.context_processors.request',
-      'django.contrib.messages.context_processors.messages',
-      'django_facebook.context_processors.facebook',
-  )
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    'django.template.context_processors.debug',
+                    'django.template.context_processors.request',
+                    'django.contrib.auth.context_processors.auth',
+                    'django.contrib.messages.context_processors.messages',
+                    'django_facebook.context_processors.facebook',
+                ],
+            },
+        },
+    ]
 
 **Auth backend**
 
-Add this to your ``AUTHENTICATION_BACKENDS`` setting::
+Add these to your ``AUTHENTICATION_BACKENDS`` setting::
 
     'django_facebook.auth_backends.FacebookBackend',
+    'django.contrib.auth.backends.ModelBackend',
 
-The full setting on a new django 1.5 app looks like this::
+The full setting on a new django 1.11 app looks like this::
 
   AUTHENTICATION_BACKENDS = (
       'django_facebook.auth_backends.FacebookBackend',
@@ -75,8 +81,8 @@ The full setting on a new django 1.5 app looks like this::
 **3.) Urls**
 Now, add this line to your url config::
 
-    (r'^facebook/', include('django_facebook.urls')),
-    (r'^accounts/', include('django_facebook.auth_urls')), #Don't add this line if you use django registration or userena for registration and auth.
+    url(r'^facebook/', include('django_facebook.urls')),
+    url(r'^accounts/', include('django_facebook.auth_urls')), #Don't add this line if you use django registration or userena for registration and auth.
 
 
 **4.) Update your models**
@@ -101,7 +107,7 @@ If you don't already have a custom Profile model, simply uses the provided model
 
     AUTH_PROFILE_MODULE = 'django_facebook.FacebookProfile'
 
-Be sure to run manage.py syncdb after setting this up.
+Be sure to sync the database via ``python manage.py migrate --run-syncdb`` after setting this up.
 
 Otherwise Django Facebook provides an abstract model which you can inherit like this.
 ::

--- a/facebook_example/facebook_example/settings.py
+++ b/facebook_example/facebook_example/settings.py
@@ -15,19 +15,37 @@ TESTING = 'test' in sys.argv
 
 FACEBOOK_APP_ID = '215464901804004'
 FACEBOOK_APP_SECRET = '0aceba27823a9dfefa955f76949fa4b4'
-TEMPLATE_CONTEXT_PROCESSORS = [
-    'django.contrib.auth.context_processors.auth',
-    'django.core.context_processors.debug',
-    'django.core.context_processors.i18n',
-    'django.core.context_processors.media',
-    'django.core.context_processors.static',
-    'django.core.context_processors.request',
-    'django.contrib.messages.context_processors.messages',
-    'django_facebook.context_processors.facebook',
-]
+if django_version < (1, 10, 0):
+    TEMPLATE_CONTEXT_PROCESSORS = [
+        'django.contrib.auth.context_processors.auth',
+        'django.core.context_processors.debug',
+        'django.core.context_processors.i18n',
+        'django.core.context_processors.media',
+        'django.core.context_processors.static',
+        'django.core.context_processors.request',
+        'django.contrib.messages.context_processors.messages',
+        'django_facebook.context_processors.facebook',
+    ]
 
-if django_version >= (1, 4, 0):
-    TEMPLATE_CONTEXT_PROCESSORS.append('django.core.context_processors.tz')
+    if django_version >= (1, 4, 0):
+        TEMPLATE_CONTEXT_PROCESSORS.append('django.core.context_processors.tz')
+else:
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    'django.template.context_processors.debug',
+                    'django.template.context_processors.request',
+                    'django.contrib.auth.context_processors.auth',
+                    'django.contrib.messages.context_processors.messages',
+                    'django_facebook.context_processors.facebook',
+                ],
+            },
+        },
+    ]
 
 AUTHENTICATION_BACKENDS = (
     'django_facebook.auth_backends.FacebookBackend',

--- a/facebook_example/facebook_example/urls.py
+++ b/facebook_example/facebook_example/urls.py
@@ -1,5 +1,5 @@
 try:
-    from django.conf.urls import include, patterns, url
+    from django.conf.urls import include, url
 except ImportError:
     from django.conf.urls.defaults import include, url
 from django.conf import settings

--- a/open_facebook/api.py
+++ b/open_facebook/api.py
@@ -848,7 +848,7 @@ class OpenFacebook(FacebookConnection):
         '''
         me = getattr(self, '_me', None)
         if me is None:
-            #self._me = me = self.get('me')
+            # self._me = me = self.get('me')
             self._me = me = self.get('me', fields="id,name,email,verified")
 
         return me


### PR DESCRIPTION
`getLogger` now produces a cryptic error saying a handler could not be found, which suppresses all error messages. I have opted to remove `getLogger` and just use the default logger always.

Apologize for combining a feature (django 1.11 support) to a bugfix (fixing the other failing tests). Let me know if you'd like them separated into two PRs.