### PR TITLE
Empty email field solutions

### DIFF
--- a/django_facebook/connect.py
+++ b/django_facebook/connect.py
@@ -228,6 +228,9 @@ def _register_user(request, facebook, profile_callback=None,
             request.GET.get('force_registration_hard'):
         data['email'] = data['email'].replace(
             '@', '+test%s@' % randint(0, 1000000000))
+        
+    if not data['email']:
+        data['email'] = '%s@facebook.com' % data['username'] 
 
     form = form_class(data=data, files=request.FILES,
                       initial={'ip': request.META['REMOTE_ADDR']})

--- a/open_facebook/api.py
+++ b/open_facebook/api.py
@@ -949,6 +949,9 @@ class OpenFacebook(FacebookConnection):
 
         if path and path.startswith('/'):
             path = path[1:]
+            
+        if path == 'me':
+            params['fields'] = 'email,first_name,last_name,name,cover,picture'
 
         url = '/'.join([api_base_url, version, path])
         return '%s?%s' % (url, urlencode(params))


### PR DESCRIPTION
These edits solve two issues leading to empty email fields from the Graph API. 
1. The email field is explicitly required in the API call. 
2. User didn't give permission or because of Facebook privacy/security policies. 

[Refer Facebook bug](https://developers.facebook.com/bugs/298946933534016/)