### PR TITLE
docs: fix simple typo, rsponse -> response

### DIFF
--- a/docs/docs_env/Lib/site-packages/pip-1.0-py2.5.egg/pip/download.py
+++ b/docs/docs_env/Lib/site-packages/pip-1.0-py2.5.egg/pip/download.py
@@ -101,7 +101,7 @@ class URLOpener(object):
 
     def get_response(self, url, username=None, password=None):
         """
-        does the dirty work of actually getting the rsponse object using urllib2
+        does the dirty work of actually getting the response object using urllib2
         and its HTTP auth builtins.
         """
         scheme, netloc, path, query, frag = urlparse.urlsplit(url)


### PR DESCRIPTION
There is a small typo in docs/docs_env/Lib/site-packages/pip-1.0-py2.5.egg/pip/download.py.

Should read `response` rather than `rsponse`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md