### PR TITLE
Setuptools v59 compliance

### DIFF
--- a/README.rest
+++ b/README.rest
@@ -9,6 +9,13 @@ Django Facebook by Thierry Schellenbach (`mellowmorning.com <http://www.mellowmo
         :target: https://pypi.python.org/pypi/django-facebook
 
 
+Overview
+-------
+Facebook open graph API client in Python. Enables django applications to register users using facebook.
+Fixes issues with the official but unsupported Facebook python-sdk. Enables mobile facebook authentication.
+Canvas page authentication for facebook applications. FQL access via the server side api.
+
+
 Status
 -------
 Django and Facebook are both rapidly changing at the moment. Meanwhile, I'm caught up in a startup and don't have much spare time.

--- a/setup.py
+++ b/setup.py
@@ -121,10 +121,7 @@ CLASSIFIERS = [
     'Environment :: Web Environment',
 ]
 
-DESCRIPTION = """Facebook open graph API client in python. Enables django applications to register users using facebook.
-Fixes issues with the official but unsupported Facebook python-sdk. Enables mobile facebook authentication.
-Canvas page authentication for facebook applications. FQL access via the server side api.
-"""
+DESCRIPTION = "Facebook open graph API client in Python"
 
 download_url = 'https://github.com/tschellenbach/Django-facebook/archive/v%s.tar.gz' % __version__
 


### PR DESCRIPTION
Setuptools description fields are intended to be only 1 line (see: https://setuptools.pypa.io/en/latest/references/keywords.html).

This is now mandated in Setuptools v59, which has been breaking some build processes.

This PR fixes the description length, and moves the more verbose description to the Readme.

See this issue for more context: https://github.com/pypa/setuptools/issues/2893